### PR TITLE
Update stub-builder.ts to support falsy overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-stubber",
   "description": "Lazy Stubbing a TypeScript Class or Interface with any Mocking Framework for testing in Isolation",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "author": "Shelly Goldblit",
   "private": false,
   "license": "MIT",

--- a/src/stub-builder.ts
+++ b/src/stub-builder.ts
@@ -66,7 +66,7 @@ export const StubbedInstanceCreator = <T, StubT>(
       target: Record<string, unknown>,
       prop: string
     ) => {
-      if (!target[prop]) {
+      if (!(prop in target)) {
         target[prop] = createStub(prop);
       }
     };


### PR DESCRIPTION
The current override logic checks if an override property exists by using falsy logic to check its value, so if an override defined with a value of `false` or `0`, the override will instead be mocked.

Using the `in` operator checks if the property exists rather than checking the value of the property, allowing these overrides